### PR TITLE
VOC Sensor bug of re-initialization Fixed

### DIFF
--- a/components/gpio_setup/i2c_config.c
+++ b/components/gpio_setup/i2c_config.c
@@ -62,7 +62,8 @@
          .i2c_port = I2C_PORT,
          .scl_io_num = I2C_SCL_PIN,
          .sda_io_num = I2C_SDA_PIN,
-         .clk_source = I2C_CLK_SRC_DEFAULT
+         .clk_source = I2C_CLK_SRC_DEFAULT,
+         .flags.enable_internal_pullup = 1
      };
  
      esp_err_t err = i2c_new_master_bus(&i2c_conf, &i2c_bus_handle);

--- a/components/sensors/general_sensors.h
+++ b/components/sensors/general_sensors.h
@@ -24,7 +24,7 @@ typedef struct {
     uint16_t average_co2;
     uint16_t average_temp;
     uint16_t average_humidity;
-    uint16_t  average_voc;
+    uint16_t average_voc;
     uint16_t co2_user_threshold;
     uint16_t co2_generally_unsafe_value;
     uint16_t voc_user_threshold;

--- a/main/main.c
+++ b/main/main.c
@@ -17,7 +17,7 @@
 #include "Userbuttons.h"
 #include "esp_sleep.h"
 
-#define WAKEUP_TIME 5000000  // one second
+#define WAKEUP_TIME 5000000  // five seconds
 
 // Needs to do something with this here, will not work because then on ever wake from deep sleep, current page is startup
 RTC_DATA_ATTR display_screen_pages_t current_page = STARTUP_SCREEN;
@@ -38,7 +38,7 @@ void deep_sleep_monitor_task(void *parameter)
     // Check if all mutexes are free, recent user interaction, and the status of the two buzzers
     while((uxSemaphoreGetCount(temp_humid_mutex) == 0) || (uxSemaphoreGetCount(co2_mutex) == 0) || (uxSemaphoreGetCount(voc_mutex) == 0) || check_recent_user_interaction() || is_user_buzzer_on() || is_safety_buzzer_on())
     {
-        vTaskDelay(pdMS_TO_TICKS(100));
+        vTaskDelay(pdMS_TO_TICKS(500));
     }
 
     // will sleep for 5 seconds then wakeup for more readings
@@ -63,7 +63,7 @@ void app_main()
     xTaskCreate(temp_humidity_task, "TEMP_HUMIDITY_TASk", 1024 * 3, NULL, 5, NULL);
     xTaskCreate(co2_task, "CO2_TASK", 1024 * 3, NULL, 5, NULL);
     xTaskCreate(voc_task, "VOC_TASK", 1024 * 3, NULL, 5, NULL);
-    xTaskCreate(display_task, "DISPLAY_TASK", 1024 * 3, NULL, 4, NULL);
+    xTaskCreate(display_task, "DISPLAY_TASK", 1024 * 4, NULL, 4, NULL);
     xTaskCreate(user_button_task, "BUTTON_TASK", 1024 * 4, NULL, 6, NULL);
    
     //Lowest priority task


### PR DESCRIPTION
There was an issue where if a button was pressed on initial startup, then after the two minutes had passed, the VOC sensor would keep re-initializing. This issue was fixed by using a flag rather than checking the wakeup reason before initializing the sensor